### PR TITLE
feat: add CI and rollout workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: ci
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+jobs:
+  test-and-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: apps/ingest-api/go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./...
+        working-directory: apps/ingest-api
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+          working-directory: apps/ingest-api
+
+      - name: Run gosec security scanner
+        uses: securego/gosec@v2
+        with:
+          args: ./...
+          working-directory: apps/ingest-api
+
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@v0.12.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}/ingest-api:${{ github.sha }}
+
+      - name: Setup Infracost
+        uses: infracost/actions/setup@v2
+
+      - name: Run Infracost
+        uses: infracost/actions/comment@v2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}
+        with:
+          path: infra

--- a/.github/workflows/rollout-update.yml
+++ b/.github/workflows/rollout-update.yml
@@ -1,0 +1,41 @@
+name: rollout-update
+
+on:
+  workflow_dispatch:
+    inputs:
+      rollout:
+        description: 'Argo Rollout name'
+        required: true
+      namespace:
+        description: 'Kubernetes namespace'
+        required: true
+        default: default
+      image:
+        description: 'New container image'
+        required: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: v1.30.0
+
+      - name: Install Argo Rollouts plugin
+        run: |
+          curl -sLO https://github.com/argoproj/argo-rollouts/releases/latest/download/kubectl-argo-rollouts-linux-amd64
+          chmod +x kubectl-argo-rollouts-linux-amd64
+          sudo mv kubectl-argo-rollouts-linux-amd64 /usr/local/bin/kubectl-argo-rollouts
+
+      - name: Update rollout image
+        run: |
+          kubectl-argo-rollouts set image ${{ inputs.rollout }} *=${{ inputs.image }} -n ${{ inputs.namespace }}
+        env:
+          KUBECONFIG: ${{ secrets.KUBECONFIG }}


### PR DESCRIPTION
## Summary
- add CI workflow running Go tests with module caching, linting, Trivy scan, and Infracost comments
- add rollout-update workflow to promote new images via Argo Rollouts

## Testing
- `go test ./...` *(fails: no required module provides package go.opentelemetry.io/otel/exporters/stdout/stdoutmetric)*
- `./actionlint .github/workflows/ci.yml .github/workflows/rollout-update.yml`


------
https://chatgpt.com/codex/tasks/task_e_689624db453c8329b37b76356cbd9c6c