### PR TITLE
Add broker and topic handling to MQTT consumer

### DIFF
--- a/apps/ingest-api/internal/mqtt/consumer.go
+++ b/apps/ingest-api/internal/mqtt/consumer.go
@@ -3,12 +3,16 @@ package mqtt
 import (
 	"context"
 
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+
 	"ingest/internal/service"
 )
 
 // Consumer represents an MQTT consumer that feeds messages to the processor.
 type Consumer struct {
 	client    mqtt.Client
+	broker    string
+	topic     string
 	processor *service.Processor
 }
 


### PR DESCRIPTION
## Summary
- Extend MQTT consumer with broker and topic fields
- Simplify server to construct consumer directly with broker and ingest topic

## Testing
- `go test ./internal/mqtt/... -count=1`
