### PR TITLE
chore: update ingest-api to Go 1.23

### DIFF
--- a/apps/ingest-api/Dockerfile
+++ b/apps/ingest-api/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24 AS build
+FROM golang:1.23 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/apps/ingest-api/go.mod
+++ b/apps/ingest-api/go.mod
@@ -1,6 +1,8 @@
 module ingest
 
-go 1.24.3
+go 1.23.0
+
+toolchain go1.24.3
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.40.1
@@ -10,11 +12,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.37.0
 	go.opentelemetry.io/otel/sdk/metric v1.37.0
 	go.opentelemetry.io/otel/trace v1.37.0
-)
-
-require (
-	github.com/eclipse/paho.mqtt.golang v1.5.0
-	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.37.0
 )
 
 require (

--- a/apps/ingest-api/go.sum
+++ b/apps/ingest-api/go.sum
@@ -138,3 +138,4 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+


### PR DESCRIPTION
## Summary
- use released Go 1.23 and tidy module deps
- refresh go.sum
- build ingest-api Dockerfile from golang:1.23

## Testing
- `go test -mod=mod ./...` *(fails: undefined: mqtt)*
- `docker build -t ingest-api:test apps/ingest-api` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*