### PR TITLE
Add CI workflow for tests, Trivy, and Infracost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: ci
+
+on:
+  push:
+    branches: ['*']
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  test-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: apps/ingest-api/go.mod
+          cache: true
+
+      - name: Run tests
+        working-directory: apps/ingest-api
+        run: go test ./...
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@v0.12.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}/ingest-api:${{ github.sha }}
+
+      - name: Infracost comment
+        uses: infracost/actions/comment@v2
+        env:
+          INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}
+        with:
+          path: infra
+          behavior: update
+          github-token: ${{ github.token }}

--- a/.github/workflows/rollout-update.yml
+++ b/.github/workflows/rollout-update.yml
@@ -1,0 +1,21 @@
+name: rollout-update
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: v1.30.0
+
+      - name: Update rollout image
+        uses: argoproj/rollouts-actions@v2
+        env:
+          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+        with:
+          namespace: default
+          args: set image ingest-api ingest-api=ghcr.io/${{ github.repository }}/ingest-api:${{ github.sha }} --record


### PR DESCRIPTION
## Summary
- add CI workflow running Go tests, Trivy scan, and Infracost comment with caching for Go modules
- add rollout-update workflow for progressive delivery

## Testing
- `go test ./...` *(fails: undefined: mqtt)*
- `trivy fs --quiet --skip-java-db-update .`


------
https://chatgpt.com/codex/tasks/task_e_6896383637e883299a0df6afd4de836c