### PR TITLE
Add ingest Rollout with Prometheus latency analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ jobs:
 * Rollout manifest defines analysis template querying Prometheus metric `ingest_latency_p95`.
 * Steps: 10 % → pause 2 min → 50 % → pause 5 min → full.
 * Auto‑abort if latency increase > 20 % baseline.
+* Monitor rollout with `kubectl argo rollouts get rollout ingest-api -w -n <env>` or via the Argo Rollouts dashboard.
+* Roll back instantly with `kubectl argo rollouts undo ingest-api -n <env>`.
 
 ---
 

--- a/argo-rollouts/ingest-rollout.yaml
+++ b/argo-rollouts/ingest-rollout.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: ingest-latency
+spec:
+  metrics:
+    - name: ingest-latency-p95
+      interval: 1m
+      count: 3
+      successCondition: result[0] < 0.3
+      failureCondition: result[0] > 0.5
+      provider:
+        prometheus:
+          address: http://prometheus.monitoring:9090
+          query: ingest_latency_p95
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: ingest-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ingest-api
+  template:
+    metadata:
+      labels:
+        app: ingest-api
+    spec:
+      containers:
+        - name: ingest-api
+          image: ghcr.io/outback-uptime/ingest-api:latest
+          ports:
+            - containerPort: 80
+  strategy:
+    canary:
+      analysis:
+        templates:
+          - templateName: ingest-latency
+      steps:
+        - setWeight: 10
+        - pause:
+            duration: 2m
+        - setWeight: 50
+        - pause:
+            duration: 5m
+        - setWeight: 100

--- a/flux/overlays/dev/kustomization.yaml
+++ b/flux/overlays/dev/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: dev
 resources:
+  - ../../../argo-rollouts/ingest-rollout.yaml
   - ingest-api.yaml
   - clickhouse.yaml
   - linkerd.yaml

--- a/flux/overlays/prod/kustomization.yaml
+++ b/flux/overlays/prod/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: prod
 resources:
+  - ../../../argo-rollouts/ingest-rollout.yaml
   - ingest-api.yaml
   - clickhouse.yaml
   - linkerd.yaml


### PR DESCRIPTION
## Summary
- add Argo Rollouts manifest for ingest-api with canary steps and Prometheus p95 latency check
- include rollout manifest in dev and prod Flux overlays for automatic deployment
- document monitoring and rollback commands in README

## Testing
- `kustomize build flux/overlays/dev --load-restrictor=LoadRestrictionsNone`
- `kustomize build flux/overlays/prod --load-restrictor=LoadRestrictionsNone`

