### PR TITLE
Add MQTT simulation compose file and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ linkerd install | kubectl apply -f -
 linkerd check
 ```
 
-Edge emulation: `docker compose -f edge/docker-compose.sim.yaml up` publishes MQTT messages.
+Edge emulation: run `docker compose -f edge/docker-compose.sim.yaml up` to start an MQTT broker and publish sample telemetry every 30 seconds.
 
 ### Edge Deployment & Failover Drill
 

--- a/edge/docker-compose.sim.yaml
+++ b/edge/docker-compose.sim.yaml
@@ -1,0 +1,14 @@
+version: "3.8"
+services:
+  mqtt:
+    image: eclipse-mosquitto:2
+    ports:
+      - "1883:1883"
+    restart: unless-stopped
+  publisher:
+    image: efrecon/mqtt-client:latest
+    depends_on:
+      - mqtt
+    command: >-
+      sh -c "while true; do mosquitto_pub -h mqtt -t sensors/temperature -m '{\"temp\":25}' ; sleep 30; done"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add edge/docker-compose.sim.yaml to simulate an MQTT broker and publisher emitting telemetry every 30s
- document how to run the simulator in README local development section

## Testing
- `go test ./...` (from apps/ingest-api)
- `docker-compose -f edge/docker-compose.sim.yaml config`

