### PR TITLE
Add Helmfile for cluster addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ DRY_RUN=true RESOURCE_GROUP=my-rg PROFILE_NAME=my-tm \
 2. `infra/terraform/azure` — VNet, AKS Autopilot, Traffic Manager, Storage.
 3. `edge/pulumi` — K3s install via k3sup, fleet Helm releases.
 
+4. `infra/helmfile` — Helmfile installing Linkerd, monitoring stack, Argo Rollouts, and Vault. Run `helmfile apply -e <env>` after Terraform to bootstrap the cluster.
+
 CI plans run Infracost & tfsec before merge.
 
 ---

--- a/infra/helmfile/environments/dev.yaml
+++ b/infra/helmfile/environments/dev.yaml
@@ -1,0 +1,7 @@
+linkerd:
+  ha: false
+monitoring:
+  prometheus:
+    retention: 7d
+vault:
+  replicas: 1

--- a/infra/helmfile/environments/prod.yaml
+++ b/infra/helmfile/environments/prod.yaml
@@ -1,0 +1,7 @@
+linkerd:
+  ha: true
+monitoring:
+  prometheus:
+    retention: 30d
+vault:
+  replicas: 3

--- a/infra/helmfile/helmfile.yaml
+++ b/infra/helmfile/helmfile.yaml
@@ -1,0 +1,42 @@
+environments:
+  dev:
+    values:
+      - environments/dev.yaml
+  prod:
+    values:
+      - environments/prod.yaml
+
+repositories:
+  - name: argo
+    url: https://argoproj.github.io/argo-helm
+  - name: hashicorp
+    url: https://helm.releases.hashicorp.com
+  - name: prometheus-community
+    url: https://prometheus-community.github.io/helm-charts
+
+releases:
+  - name: linkerd
+    namespace: linkerd
+    chart: ../../charts/linkerd
+    values:
+      - ha: {{ .Values.linkerd.ha }}
+
+  - name: monitoring
+    namespace: monitoring
+    chart: prometheus-community/kube-prometheus-stack
+    values:
+      - prometheus:
+          prometheusSpec:
+            retention: {{ .Values.monitoring.prometheus.retention }}
+
+  - name: argo-rollouts
+    namespace: argo-rollouts
+    chart: argo/argo-rollouts
+
+  - name: vault
+    namespace: vault
+    chart: hashicorp/vault
+    values:
+      - server:
+          ha:
+            replicas: {{ .Values.vault.replicas }}


### PR DESCRIPTION
## Summary
- manage Linkerd, monitoring stack, Argo Rollouts, and Vault via Helmfile
- add dev and prod environment values
- document running `helmfile apply` during cluster provisioning

## Testing
- `go test ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*
- `cd apps/ingest-api && go test ./... && cd -`
- `helmfile -f infra/helmfile/helmfile.yaml lint -e dev`


