### PR TITLE
chore: target Go 1.23 release for ingest API

### DIFF
--- a/apps/ingest-api/Dockerfile
+++ b/apps/ingest-api/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23 AS build
+FROM golang:1.23.12 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/apps/ingest-api/go.mod
+++ b/apps/ingest-api/go.mod
@@ -1,8 +1,6 @@
 module ingest
 
-go 1.23.0
-
-toolchain go1.24.3
+go 1.23
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.40.1


### PR DESCRIPTION
## Summary
- target Go 1.23 release and drop `toolchain` directive
- use Go 1.23.12 in ingest API Dockerfile

## Testing
- `go mod tidy`
- `go build ./cmd/server` *(fails: updates to go.mod needed)*
- `docker build -t ingest-api-test apps/ingest-api` *(fails: Cannot connect to the Docker daemon)*

